### PR TITLE
Refactor `SlpWriter`, get SLP data  for all inputs

### DIFF
--- a/chronik-rocksdb/src/indexdb.rs
+++ b/chronik-rocksdb/src/indexdb.rs
@@ -177,7 +177,7 @@ impl IndexDb {
         timings.timings.stop_timer("spends");
 
         timings.timings.start_timer();
-        slp_writer.insert_block_txs(&mut batch, first_tx_num, txs, txids_fn)?;
+        slp_writer.insert_block_txs(&mut batch, first_tx_num, txs, txids_fn, &input_tx_nums)?;
         timings.timings.stop_timer("slp");
 
         timings.timings.start_timer();

--- a/chronik-rocksdb/src/mempool.rs
+++ b/chronik-rocksdb/src/mempool.rs
@@ -113,8 +113,8 @@ mod tests {
     use rocksdb::WriteBatch;
 
     use crate::{
-        BlockTxs, Db, MempoolData, MempoolSlpData, MempoolTxEntry, MempoolWriter, SlpWriter,
-        TxEntry, TxWriter,
+        input_tx_nums::fetch_input_tx_nums, BlockTxs, Db, MempoolData, MempoolSlpData,
+        MempoolTxEntry, MempoolWriter, SlpWriter, TxEntry, TxWriter,
     };
 
     #[test]
@@ -145,7 +145,14 @@ mod tests {
         {
             // Validate initial block
             let mut batch = WriteBatch::default();
-            slp_writer.insert_block_txs(&mut batch, 0, &block_txs, |idx| &block_txids[idx])?;
+            let input_tx_nums = fetch_input_tx_nums(&db, 0, |idx| &block_txids[idx], &block_txs)?;
+            slp_writer.insert_block_txs(
+                &mut batch,
+                0,
+                &block_txs,
+                |idx| &block_txids[idx],
+                &input_tx_nums,
+            )?;
             let block_txs = block_txids
                 .iter()
                 .cloned()

--- a/chronik-rocksdb/src/mempool_slp_data.rs
+++ b/chronik-rocksdb/src/mempool_slp_data.rs
@@ -107,7 +107,10 @@ mod tests {
     use pretty_assertions::assert_eq;
     use rocksdb::WriteBatch;
 
-    use crate::{BlockTxs, Db, MempoolSlpData, SlpWriter, TxEntry, TxWriter};
+    use crate::{
+        input_tx_nums::fetch_input_tx_nums, BlockTxs, Db, MempoolSlpData, SlpWriter, TxEntry,
+        TxWriter,
+    };
 
     #[test]
     fn test_slp_mempool() -> Result<()> {
@@ -134,7 +137,14 @@ mod tests {
         {
             // Validate initial block
             let mut batch = WriteBatch::default();
-            slp_writer.insert_block_txs(&mut batch, 0, &block_txs, |idx| &block_txids[idx])?;
+            let input_tx_nums = fetch_input_tx_nums(&db, 0, |idx| &block_txids[idx], &block_txs)?;
+            slp_writer.insert_block_txs(
+                &mut batch,
+                0,
+                &block_txs,
+                |idx| &block_txids[idx],
+                &input_tx_nums,
+            )?;
             let block_txs = block_txids
                 .iter()
                 .cloned()


### PR DESCRIPTION
This is necessary for calculating token stats like current supply, total burned amount etc.

- Use `input_tx_nums` instead of fetching it ourselves
- Add `fetch_spent_slp_outputs` to fetch SLP state for *all* inputs
- Change `fetch_batch_txs` to `build_batch_txs` as it no longer fetches
- Change `fetch_known_slp_outputs` to `build_known_slp_outputs` as it no longer fetches