### PR TITLE
Simplify `slp_data_by_tx_num` return type

### DIFF
--- a/chronik-indexer/src/txs.rs
+++ b/chronik-indexer/src/txs.rs
@@ -129,7 +129,7 @@ impl<'a> Txs<'a> {
             }
         }
         let (slp_tx_data, slp_burns) = match slp_reader.slp_data_by_tx_num(tx_num)? {
-            Some((slp_tx_data, slp_burns)) => (Some(slp_tx_data), slp_burns),
+            Some(slp) => (Some(slp.slp_tx_data), slp.slp_burns),
             None => (
                 None,
                 tx.inputs
@@ -203,15 +203,16 @@ impl<'a> Txs<'a> {
             .tx_num_by_txid(&outpoint.txid)?
             .expect("Inconsistent index");
         match slp_reader.slp_data_by_tx_num(tx_num)? {
-            Some((slp_tx_data, _)) => {
-                let token = slp_tx_data
+            Some(slp) => {
+                let token = slp
+                    .slp_tx_data
                     .output_tokens
                     .get(outpoint.out_idx as usize)
                     .cloned()
                     .unwrap_or_default();
                 Ok(Some(Box::new(SlpBurn {
                     token,
-                    token_id: slp_tx_data.token_id,
+                    token_id: slp.slp_tx_data.token_id,
                 })))
             }
             None => Ok(None),

--- a/chronik-indexer/src/utxos.rs
+++ b/chronik-indexer/src/utxos.rs
@@ -97,17 +97,18 @@ impl<'a> Utxos<'a> {
                 let slp_output =
                     slp_reader
                         .slp_data_by_tx_num(db_utxo.outpoint.tx_num)?
-                        .map(|(slp_data, _)| {
+                        .map(|slp| {
                             Box::new(SlpOutput {
-                                token_id: slp_data.token_id,
-                                tx_type: slp_data.slp_tx_type.tx_type_variant(),
-                                token_type: slp_data.slp_token_type,
-                                token: slp_data
+                                token_id: slp.slp_tx_data.token_id,
+                                tx_type: slp.slp_tx_data.slp_tx_type.tx_type_variant(),
+                                token_type: slp.slp_tx_data.slp_token_type,
+                                token: slp
+                                    .slp_tx_data
                                     .output_tokens
                                     .get(out_idx)
                                     .cloned()
                                     .unwrap_or_default(),
-                                group_token_id: slp_data.group_token_id,
+                                group_token_id: slp.slp_tx_data.group_token_id,
                             })
                         });
                 let rich_utxo = RichUtxo {

--- a/chronik-rocksdb/src/mempool_slp_data.rs
+++ b/chronik-rocksdb/src/mempool_slp_data.rs
@@ -63,13 +63,13 @@ impl MempoolSlpData {
                         .tx_num_by_txid(&input.prev_out.txid)?
                         .and_then(|tx_num| slp_reader.slp_data_by_tx_num(tx_num).transpose())
                         .transpose()?
-                        .and_then(|(slp_tx_data, _)| {
-                            let token = *slp_tx_data.output_tokens.get(out_idx)?;
+                        .and_then(|slp| {
+                            let token = *slp.slp_tx_data.output_tokens.get(out_idx)?;
                             Some(SlpSpentOutput {
-                                token_id: slp_tx_data.token_id,
-                                token_type: slp_tx_data.slp_token_type,
+                                token_id: slp.slp_tx_data.token_id,
+                                token_type: slp.slp_tx_data.slp_token_type,
                                 token,
-                                group_token_id: slp_tx_data.group_token_id,
+                                group_token_id: slp.slp_tx_data.group_token_id,
                             })
                         }),
                 },


### PR DESCRIPTION
Use existing `SlpValidTxData` struct instead of awkward tuple.