### PR TITLE
Index transient data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,7 @@ dependencies = [
  "json",
  "pretty_assertions",
  "rayon",
+ "seahash",
  "tempdir",
  "thiserror",
  "tokio",

--- a/chronik-http/tests/test_chronik.rs
+++ b/chronik-http/tests/test_chronik.rs
@@ -12,7 +12,9 @@ use bitcoinsuite_test_utils::{bin_folder, is_free_tcp, pick_ports};
 use bitcoinsuite_test_utils_blockchain::build_tx;
 use chronik_http::{proto, ChronikServer, CONTENT_TYPE_PROTOBUF};
 use chronik_indexer::SlpIndexer;
-use chronik_rocksdb::{Db, IndexDb, IndexMemData, PayloadPrefix, ScriptPayload, ScriptTxsConf};
+use chronik_rocksdb::{
+    Db, IndexDb, IndexMemData, PayloadPrefix, ScriptPayload, ScriptTxsConf, TransientData,
+};
 use futures::{SinkExt, StreamExt};
 use hyper::{header::CONTENT_TYPE, StatusCode};
 use pretty_assertions::assert_eq;
@@ -47,7 +49,8 @@ async fn test_server() -> Result<()> {
     let rpc_interface = RpcInterface::open(&rpc_url)?;
     let outputs_conf = ScriptTxsConf { page_size: 7 };
     let db = Db::open(dir.path().join("index.rocksdb"))?;
-    let db = IndexDb::new(db, outputs_conf);
+    let transient_data = TransientData::open(&dir.path().join("transient.rocksdb"))?;
+    let db = IndexDb::new(db, transient_data, outputs_conf);
     let bitcoind = instance.cli();
     let cache = IndexMemData::new(10);
     let mut slp_indexer = SlpIndexer::new(

--- a/chronik-indexer/Cargo.toml
+++ b/chronik-indexer/Cargo.toml
@@ -34,3 +34,6 @@ tempdir = "0.3"
 
 bitcoinsuite-test-utils-blockchain = { path = "../../bitcoinsuite/bitcoinsuite-test-utils-blockchain" }
 bitcoinsuite-ecc-secp256k1 = { path = "../../bitcoinsuite/bitcoinsuite-ecc-secp256k1" }
+
+# Fast hashing (not cryptographic)
+seahash = "4.1"

--- a/chronik-indexer/tests/test_mempool.rs
+++ b/chronik-indexer/tests/test_mempool.rs
@@ -26,7 +26,7 @@ use chronik_indexer::{
 };
 use chronik_rocksdb::{
     BlockStats, Db, IndexDb, IndexMemData, MempoolTxEntry, PayloadPrefix, ScriptPayload,
-    ScriptTxsConf, TokenStats,
+    ScriptTxsConf, TokenStats, TransientData,
 };
 use pretty_assertions::{assert_eq, assert_ne};
 use tempdir::TempDir;
@@ -54,9 +54,10 @@ async fn test_mempool() -> Result<()> {
     instance.wait_for_ready()?;
     let pub_interface = PubInterface::open(&pub_url)?;
     let rpc_interface = RpcInterface::open(&rpc_url)?;
-    let outputs_conf = ScriptTxsConf { page_size: 7 };
+    let script_txs_conf = ScriptTxsConf { page_size: 7 };
     let db = Db::open(dir.path().join("index.rocksdb"))?;
-    let db = IndexDb::new(db, outputs_conf);
+    let transient_data = TransientData::open(&dir.path().join("transient.rocksdb"))?;
+    let db = IndexDb::new(db, transient_data, script_txs_conf);
     let bitcoind = instance.cli();
     let cache = IndexMemData::new(10);
     let mut slp_indexer = SlpIndexer::new(

--- a/chronik-indexer/tests/test_non_slp.rs
+++ b/chronik-indexer/tests/test_non_slp.rs
@@ -16,7 +16,7 @@ use bitcoinsuite_test_utils::bin_folder;
 use chronik_indexer::SlpIndexer;
 use chronik_rocksdb::{
     BlockTx, Db, IndexDb, IndexMemData, OutpointEntry, PayloadPrefix, ScriptPayload, ScriptTxsConf,
-    ScriptTxsReader, TxEntry, UtxoEntry, UtxosReader,
+    ScriptTxsReader, TransientData, TxEntry, UtxoEntry, UtxosReader,
 };
 use pretty_assertions::assert_eq;
 use tempdir::TempDir;
@@ -45,7 +45,8 @@ async fn test_non_slp() -> Result<()> {
     let rpc_interface = RpcInterface::open(&rpc_url)?;
     let script_txs_conf = ScriptTxsConf { page_size: 1000 };
     let db = Db::open(dir.path().join("index.rocksdb"))?;
-    let db = IndexDb::new(db, script_txs_conf);
+    let transient_data = TransientData::open(&dir.path().join("transient.rocksdb"))?;
+    let db = IndexDb::new(db, transient_data, script_txs_conf);
     let bitcoin_cli = instance.cli();
     let cache = IndexMemData::new(10);
     let mut slp_indexer = SlpIndexer::new(

--- a/chronik-indexer/tests/test_slp.rs
+++ b/chronik-indexer/tests/test_slp.rs
@@ -20,7 +20,7 @@ use chronik_indexer::{
     broadcast::{BroadcastError, SlpBurns},
     SlpIndexer,
 };
-use chronik_rocksdb::{Db, IndexDb, IndexMemData, PayloadPrefix, ScriptTxsConf};
+use chronik_rocksdb::{Db, IndexDb, IndexMemData, PayloadPrefix, ScriptTxsConf, TransientData};
 use pretty_assertions::assert_eq;
 use tempdir::TempDir;
 
@@ -46,9 +46,10 @@ async fn test_slp() -> Result<()> {
     instance.wait_for_ready()?;
     let pub_interface = PubInterface::open(&pub_url)?;
     let rpc_interface = RpcInterface::open(&rpc_url)?;
-    let outputs_conf = ScriptTxsConf { page_size: 7 };
+    let script_txs_conf = ScriptTxsConf { page_size: 7 };
     let db = Db::open(dir.path().join("index.rocksdb"))?;
-    let db = IndexDb::new(db, outputs_conf);
+    let transient_data = TransientData::open(&dir.path().join("transient.rocksdb"))?;
+    let db = IndexDb::new(db, transient_data, script_txs_conf);
     let bitcoind = instance.cli();
     let cache = IndexMemData::new(10);
     let mut slp_indexer = SlpIndexer::new(

--- a/chronik-indexer/tests/test_transient_data.rs
+++ b/chronik-indexer/tests/test_transient_data.rs
@@ -1,0 +1,168 @@
+use std::{ffi::OsString, str::FromStr, sync::Arc};
+
+use bitcoinsuite_bitcoind::instance::{BitcoindChain, BitcoindConf, BitcoindInstance};
+use bitcoinsuite_bitcoind_nng::{PubInterface, RpcInterface};
+use bitcoinsuite_core::{
+    BitcoinCode, Hashed, LotusAddress, Net, Network, Script, Sha256d, ShaRmd160, TxOutput,
+    LOTUS_PREFIX,
+};
+use bitcoinsuite_ecc_secp256k1::EccSecp256k1;
+use bitcoinsuite_error::Result;
+use bitcoinsuite_test_utils::bin_folder;
+use bitcoinsuite_test_utils_blockchain::{build_tx, setup_bitcoind_coins};
+use chronik_indexer::{run_transient_data_catchup, SlpIndexer};
+use chronik_rocksdb::{Db, IndexDb, IndexMemData, ScriptTxsConf, TransientData};
+use pretty_assertions::assert_eq;
+use tempdir::TempDir;
+use tokio::sync::RwLock;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_transient_data() -> Result<()> {
+    bitcoinsuite_error::install()?;
+    let dir = TempDir::new("slp-indexer-test-mempool")?;
+    let pub_url = format!("ipc://{}", dir.path().join("pub.pipe").to_string_lossy());
+    let rpc_url = format!("ipc://{}", dir.path().join("rpc.pipe").to_string_lossy());
+    let conf = BitcoindConf::from_chain_regtest(
+        bin_folder(),
+        BitcoindChain::XPI,
+        vec![
+            OsString::from_str(&format!("-nngpub={}", pub_url))?,
+            OsString::from_str("-nngpubmsg=blkconnected")?,
+            OsString::from_str("-nngpubmsg=blkdisconctd")?,
+            OsString::from_str("-nngpubmsg=mempooltxadd")?,
+            OsString::from_str("-nngpubmsg=mempooltxrem")?,
+            OsString::from_str(&format!("-nngrpc={}", rpc_url))?,
+        ],
+    )?;
+    let mut instance = BitcoindInstance::setup(conf)?;
+    instance.wait_for_ready()?;
+    let pub_interface = PubInterface::open(&pub_url)?;
+    let rpc_interface = RpcInterface::open(&rpc_url)?;
+    let script_txs_conf = ScriptTxsConf { page_size: 7 };
+    let db = Db::open(dir.path().join("index.rocksdb"))?;
+    let transient_data = TransientData::open(&dir.path().join("transient.rocksdb"))?;
+    let db = IndexDb::new(db, transient_data, script_txs_conf);
+    let bitcoind = instance.cli();
+    let cache = IndexMemData::new(10);
+    let slp_indexer = RwLock::new(SlpIndexer::new(
+        db,
+        instance.rpc_client().clone(),
+        rpc_interface,
+        pub_interface,
+        cache,
+        Network::XPI,
+        Arc::new(EccSecp256k1::default()),
+    )?);
+    bitcoind.cmd_string("setmocktime", &["2000000000"])?;
+
+    let anyone_script = Script::from_slice(&[0x51]);
+    let anyone_hash = ShaRmd160::digest(anyone_script.bytecode().clone());
+    let anyone_address = LotusAddress::new(LOTUS_PREFIX, Net::Regtest, Script::p2sh(&anyone_hash));
+
+    let mut utxos = setup_bitcoind_coins(
+        bitcoind,
+        Network::XPI,
+        10,
+        anyone_address.as_str(),
+        &anyone_address.script().hex(),
+    )?;
+
+    while !slp_indexer.write().await.catchup_step().await? {}
+    slp_indexer.write().await.leave_catchup()?;
+
+    // This does nothing (yet)
+    run_transient_data_catchup(&slp_indexer).await?;
+
+    {
+        // Transient data caught up already
+        let slp_indexer = slp_indexer.read().await;
+        let transient_data = slp_indexer.db().transient_data();
+        for i in 0..=110 {
+            assert_eq!(
+                transient_data.read_block(i)?,
+                Some(chronik_rocksdb::proto::TransientBlockData { tx_data: vec![] }),
+                "block height = {}",
+                i,
+            );
+        }
+        assert_eq!(transient_data.read_block(111)?, None);
+
+        // Clear transient data caught up already
+        for i in 0..=110 {
+            slp_indexer.db().transient_data_writer().delete_block(i)?;
+        }
+
+        assert_eq!(transient_data.read_block(0)?, None);
+    }
+
+    let txid = {
+        let mut slp_indexer = slp_indexer.write().await;
+        // Add block with 1 tx
+        let (outpoint, value) = utxos.pop().unwrap();
+        let tx = build_tx(
+            outpoint,
+            &anyone_script,
+            vec![TxOutput {
+                value: value - 10_000,
+                script: Script::opreturn(&[&[0; 100]]),
+            }],
+        );
+        let txid_hex = bitcoind.cmd_string("sendrawtransaction", &[&tx.ser().hex()])?;
+        let txid = Sha256d::from_hex_be(&txid_hex)?;
+        slp_indexer.process_next_msg()?;
+        bitcoind.cmd_json("generatetoaddress", &["1", anyone_address.as_str()])?;
+        slp_indexer.process_next_msg()?;
+
+        // Now, no new transient data will be indexed
+        let transient_data = slp_indexer.db().transient_data();
+        for i in 0..=111 {
+            assert_eq!(transient_data.read_block(i)?, None);
+        }
+
+        txid
+    };
+
+    // Runs in background, continuously catching up until it's close to the tip
+    run_transient_data_catchup(&slp_indexer).await?;
+
+    {
+        let mut slp_indexer = slp_indexer.write().await;
+        let transient_data = slp_indexer.db().transient_data();
+        // run_transient_data_catchup stops indexing 10 blocks before tip
+        for i in 0..=101 {
+            assert_eq!(
+                transient_data.read_block(i)?,
+                Some(chronik_rocksdb::proto::TransientBlockData { tx_data: vec![] }),
+                "block height = {}",
+                i,
+            );
+        }
+        assert_eq!(transient_data.read_block(102)?, None);
+
+        // Next block will catch transient data up to tip
+        bitcoind.cmd_json("generatetoaddress", &["1", anyone_address.as_str()])?;
+        slp_indexer.process_next_msg()?;
+
+        let transient_data = slp_indexer.db().transient_data();
+        for i in 0..=110 {
+            assert_eq!(
+                transient_data.read_block(i)?,
+                Some(chronik_rocksdb::proto::TransientBlockData { tx_data: vec![] }),
+                "block height = {}",
+                i,
+            );
+        }
+        assert_eq!(
+            transient_data.read_block(111)?,
+            Some(chronik_rocksdb::proto::TransientBlockData {
+                tx_data: vec![chronik_rocksdb::proto::TransientTxData {
+                    txid_hash: seahash::hash(txid.as_slice()),
+                    time_first_seen: 2_000_000_000,
+                }],
+            }),
+        );
+    }
+
+    instance.cleanup()?;
+    Ok(())
+}

--- a/chronik-rocksdb-bench/src/main.rs
+++ b/chronik-rocksdb-bench/src/main.rs
@@ -6,7 +6,9 @@ use bitcoinsuite_core::{
 };
 use bitcoinsuite_error::Result;
 use bitcoinsuite_test_utils_blockchain::build_tx;
-use chronik_rocksdb::{Block, BlockTxs, Db, IndexDb, IndexMemData, ScriptTxsConf, TxEntry};
+use chronik_rocksdb::{
+    Block, BlockTxs, Db, IndexDb, IndexMemData, ScriptTxsConf, TransientData, TxEntry,
+};
 use rand::{distributions::WeightedIndex, prelude::Distribution, Rng, SeedableRng};
 use tempdir::TempDir;
 
@@ -181,7 +183,8 @@ fn main() -> Result<()> {
     let dir = TempDir::new("chronik-rocksdb-bench")?;
     let script_txs_conf = ScriptTxsConf { page_size: 1000 };
     let db = Db::open(dir.path().join("index.rocksdb"))?;
-    let db = IndexDb::new(db, script_txs_conf);
+    let transient_data = TransientData::open(&dir.path().join("transient.rocksdb"))?;
+    let db = IndexDb::new(db, transient_data, script_txs_conf);
     let mut data = IndexMemData::new(cache_size);
     let t = Instant::now();
     for (block_height, (block, block_spent_scripts)) in blocks.iter().enumerate() {

--- a/chronik-rocksdb/src/transient_data.rs
+++ b/chronik-rocksdb/src/transient_data.rs
@@ -13,7 +13,12 @@ use crate::{data::interpret, proto, BlockHeight, BlockHeightZC, Db, TxNum, TxRea
 pub const CF_TRANSIENT_BLOCK_DATA: &str = "transient_block_data";
 
 pub struct TransientData {
-    db: rocksdb::DB,
+    rocksdb: rocksdb::DB,
+}
+
+pub struct TransientDataWriter<'a> {
+    transient_data: &'a TransientData,
+    db: &'a Db,
 }
 
 #[derive(Debug, Error, ErrorMeta)]
@@ -46,12 +51,55 @@ impl TransientData {
             CF_TRANSIENT_BLOCK_DATA,
             Options::default(),
         )];
-        let db = rocksdb::DB::open_cf_descriptors(&db_options, db_path, cfs).wrap_err(RocksDb)?;
-        Ok(TransientData { db })
+        let rocksdb =
+            rocksdb::DB::open_cf_descriptors(&db_options, db_path, cfs).wrap_err(RocksDb)?;
+        Ok(TransientData { rocksdb })
     }
 
-    pub fn update_block(&self, db: &Db, block_height: BlockHeight) -> Result<()> {
-        let tx_reader = TxReader::new(db)?;
+    pub fn read_block(
+        &self,
+        block_height: BlockHeight,
+    ) -> Result<Option<proto::TransientBlockData>> {
+        let block_data = self
+            .rocksdb
+            .get_pinned_cf(
+                self.cf_transient_block_data(),
+                BlockHeightZC::new(block_height).as_bytes(),
+            )
+            .wrap_err(RocksDb)?;
+        let block_data = match block_data {
+            Some(block_data) => block_data,
+            None => return Ok(None),
+        };
+        let block_data =
+            proto::TransientBlockData::decode(block_data.as_ref()).wrap_err(InvalidProtobuf)?;
+        Ok(Some(block_data))
+    }
+
+    pub fn next_block_height(&self) -> Result<BlockHeight> {
+        let mut iter = self
+            .rocksdb
+            .iterator_cf(self.cf_transient_block_data(), IteratorMode::End);
+        match iter.next() {
+            Some((key, _)) => Ok(interpret::<BlockHeightZC>(&key)?.get() + 1),
+            None => Ok(0),
+        }
+    }
+
+    fn cf_transient_block_data(&self) -> &CF {
+        self.rocksdb
+            .cf_handle(CF_TRANSIENT_BLOCK_DATA)
+            .expect("Missing column family 'cf_transient_block_data'")
+    }
+}
+
+impl<'a> TransientDataWriter<'a> {
+    pub fn new(transient_data: &'a TransientData, db: &'a Db) -> Self {
+        TransientDataWriter { transient_data, db }
+    }
+
+    pub fn update_block(&self, block_height: BlockHeight) -> Result<()> {
+        let tx_reader = TxReader::new(self.db)?;
         let first_tx_num = tx_reader
             .first_tx_num_by_block(block_height)?
             .ok_or(NoSuchBlock(block_height))?;
@@ -75,9 +123,10 @@ impl TransientData {
             .filter_map(|tx_data| tx_data.transpose())
             .collect::<Result<Vec<_>>>()?;
         let block_data = proto::TransientBlockData { tx_data };
-        self.db
+        self.transient_data
+            .rocksdb
             .put_cf(
-                self.cf_transient_block_data(),
+                self.transient_data.cf_transient_block_data(),
                 BlockHeightZC::new(block_height).as_bytes(),
                 &block_data.encode_to_vec(),
             )
@@ -86,49 +135,14 @@ impl TransientData {
     }
 
     pub fn delete_block(&self, block_height: BlockHeight) -> Result<()> {
-        self.db
+        self.transient_data
+            .rocksdb
             .delete_cf(
-                self.cf_transient_block_data(),
+                self.transient_data.cf_transient_block_data(),
                 BlockHeightZC::new(block_height).as_bytes(),
             )
             .wrap_err(RocksDb)?;
         Ok(())
-    }
-
-    pub fn read_block(
-        &self,
-        block_height: BlockHeight,
-    ) -> Result<Option<proto::TransientBlockData>> {
-        let block_data = self
-            .db
-            .get_pinned_cf(
-                self.cf_transient_block_data(),
-                BlockHeightZC::new(block_height).as_bytes(),
-            )
-            .wrap_err(RocksDb)?;
-        let block_data = match block_data {
-            Some(block_data) => block_data,
-            None => return Ok(None),
-        };
-        let block_data =
-            proto::TransientBlockData::decode(block_data.as_ref()).wrap_err(InvalidProtobuf)?;
-        Ok(Some(block_data))
-    }
-
-    pub fn next_block_height(&self) -> Result<BlockHeight> {
-        let mut iter = self
-            .db
-            .iterator_cf(self.cf_transient_block_data(), IteratorMode::End);
-        match iter.next() {
-            Some((key, _)) => Ok(interpret::<BlockHeightZC>(&key)?.get()),
-            None => Ok(0),
-        }
-    }
-
-    fn cf_transient_block_data(&self) -> &CF {
-        self.db
-            .cf_handle(CF_TRANSIENT_BLOCK_DATA)
-            .expect("Missing column family 'cf_transient_block_data'")
     }
 }
 
@@ -139,21 +153,23 @@ mod test {
     use pretty_assertions::assert_eq;
     use rocksdb::WriteBatch;
 
-    use crate::{proto, BlockTxs, Db, TransientData, TxEntry, TxWriter};
+    use crate::{proto, BlockTxs, Db, TransientData, TransientDataWriter, TxEntry, TxWriter};
 
     #[test]
-    fn test_txs() -> Result<()> {
+    fn test_transient_data() -> Result<()> {
         bitcoinsuite_error::install()?;
         let tempdir = tempdir::TempDir::new("slp-indexer-rocks--transient-data")?;
         let db = Db::open(tempdir.path().join("data"))?;
-        let transient_db = TransientData::open(&tempdir.path().join("transient-data"))?;
+        let transient_data = TransientData::open(&tempdir.path().join("transient-data"))?;
+        let transient_writer = TransientDataWriter::new(&transient_data, &db);
         let tx_writer = TxWriter::new(&db)?;
         let tx1 = TxEntry {
             txid: Sha256d::new([1; 32]),
             time_first_seen: 123456,
             ..Default::default()
         };
-        assert_eq!(transient_db.read_block(0)?, None);
+        assert_eq!(transient_data.read_block(0)?, None);
+        assert_eq!(transient_data.next_block_height()?, 0);
         {
             // insert genesis tx
             let block_txs = BlockTxs {
@@ -163,9 +179,10 @@ mod test {
             let mut batch = WriteBatch::default();
             tx_writer.insert_block_txs(&mut batch, &block_txs)?;
             db.write_batch(batch)?;
-            transient_db.update_block(&db, 0)?;
+            transient_writer.update_block(0)?;
+            assert_eq!(transient_data.next_block_height()?, 1);
             assert_eq!(
-                transient_db.read_block(0)?,
+                transient_data.read_block(0)?,
                 Some(proto::TransientBlockData {
                     tx_data: vec![proto::TransientTxData {
                         txid_hash: seahash::hash(&[1; 32]),
@@ -193,9 +210,10 @@ mod test {
             let mut batch = WriteBatch::default();
             tx_writer.insert_block_txs(&mut batch, &block_txs)?;
             db.write_batch(batch)?;
-            transient_db.update_block(&db, 1)?;
+            transient_writer.update_block(1)?;
+            assert_eq!(transient_data.next_block_height()?, 2);
             assert_eq!(
-                transient_db.read_block(1)?,
+                transient_data.read_block(1)?,
                 Some(proto::TransientBlockData {
                     tx_data: vec![proto::TransientTxData {
                         txid_hash: seahash::hash(&[3; 32]),
@@ -209,8 +227,9 @@ mod test {
             let mut batch = WriteBatch::default();
             tx_writer.delete_block_txs(&mut batch, 1)?;
             db.write_batch(batch)?;
-            transient_db.delete_block(1)?;
-            assert_eq!(transient_db.read_block(1)?, None);
+            transient_writer.delete_block(1)?;
+            assert_eq!(transient_data.next_block_height()?, 1);
+            assert_eq!(transient_data.read_block(1)?, None);
         }
         let tx2 = TxEntry {
             txid: Sha256d::new([102; 32]),
@@ -231,9 +250,10 @@ mod test {
             let mut batch = WriteBatch::default();
             tx_writer.insert_block_txs(&mut batch, &block_txs)?;
             db.write_batch(batch)?;
-            transient_db.update_block(&db, 1)?;
+            transient_writer.update_block(1)?;
+            assert_eq!(transient_data.next_block_height()?, 2);
             assert_eq!(
-                transient_db.read_block(1)?,
+                transient_data.read_block(1)?,
                 Some(proto::TransientBlockData {
                     tx_data: vec![proto::TransientTxData {
                         txid_hash: seahash::hash(&[102; 32]),


### PR DESCRIPTION
- If transient data is far back, index it in the background
- Once transient data is close, sync it in lockstep with block updates