### PR TITLE
Add `BlockDetails` to `Block` in Protobuf

### DIFF
--- a/chronik-http/proto/chronik.proto
+++ b/chronik-http/proto/chronik.proto
@@ -80,8 +80,16 @@ message BlockInfo {
     int64 sum_burned_sats = 13;
 }
 
+message BlockDetails {
+    int32 version = 1;
+    bytes merkle_root = 2;
+    uint64 nonce = 3;
+    int64 median_timestamp = 4;
+}
+
 message Block {
     BlockInfo block_info = 1;
+    BlockDetails block_details = 3;
     repeated Tx txs = 2;
 }
 

--- a/chronik-http/tests/test_chronik.rs
+++ b/chronik-http/tests/test_chronik.rs
@@ -504,10 +504,21 @@ async fn test_server() -> Result<()> {
             hash: cur_hash.as_slice().to_vec(),
             timestamp: 2100000020,
         });
+        let block_details = proto::BlockDetails {
+            version: 1,
+            merkle_root: Sha256d::from_hex_be(
+                "824e3cc681067cb6fff43cec4281021906c37312ae19c019d71dbffd18f5fc14",
+            )?
+            .as_slice()
+            .to_vec(),
+            nonce: 0,
+            median_timestamp: 2100000019,
+        };
         assert_eq!(
             proto_block,
             proto::Block {
                 block_info: Some(block_info),
+                block_details: Some(block_details),
                 txs: vec![proto_block.txs[0].clone(), expected_tx],
             }
         )

--- a/chronik-indexer/src/indexer.rs
+++ b/chronik-indexer/src/indexer.rs
@@ -219,6 +219,10 @@ impl SlpIndexer {
         Ok(())
     }
 
+    pub fn bitcoind_rpc(&self) -> &BitcoindRpcClient {
+        &self.bitcoind
+    }
+
     pub fn db(&self) -> &IndexDb {
         &self.db
     }


### PR DESCRIPTION
Gives additional details about a block, i.e. block version, merkle root, nonce, median timestamp.