### PR TITLE
Add `size` to `Tx`

### DIFF
--- a/chronik-http/proto/chronik.proto
+++ b/chronik-http/proto/chronik.proto
@@ -43,6 +43,7 @@ message Tx {
     string slp_error_msg = 7;
     BlockMetadata block = 8;
     int64 time_first_seen = 9;
+    uint32 size = 11;
     Network network = 10;
 }
 

--- a/chronik-http/src/convert.rs
+++ b/chronik-http/src/convert.rs
@@ -91,6 +91,7 @@ pub fn rich_tx_to_proto(rich_tx: RichTx) -> proto::Tx {
             timestamp: block.timestamp,
         }),
         time_first_seen: rich_tx.time_first_seen,
+        size: rich_tx.tx.raw().len() as u32,
         network: network_to_proto(rich_tx.network) as i32,
     }
 }

--- a/chronik-http/tests/test_chronik.rs
+++ b/chronik-http/tests/test_chronik.rs
@@ -229,6 +229,7 @@ async fn test_server() -> Result<()> {
         slp_error_msg: "".to_string(),
         block: None,
         time_first_seen: 2_100_000_000,
+        size: 117,
         network: proto::Network::Xpi as i32,
     };
 


### PR DESCRIPTION
Currently, it's not easy to retrieve the size of a tx from a `Tx` message, other than painstakingly reconstructing the tx. This change adds it to the `Tx` message.