### PR TITLE
Add `raw_header` to `Block` message

### DIFF
--- a/chronik-http/proto/chronik.proto
+++ b/chronik-http/proto/chronik.proto
@@ -96,6 +96,7 @@ message BlockDetails {
 message Block {
     BlockInfo block_info = 1;
     BlockDetails block_details = 3;
+    bytes raw_header = 4;
     repeated Tx txs = 2;
 }
 

--- a/chronik-http/src/server.rs
+++ b/chronik-http/src/server.rs
@@ -253,6 +253,10 @@ async fn handle_block(
         .by_height(block.height)?
         .expect("Inconsistent index");
     let block_info = Some(block_to_info_proto(&block, &block_stats));
+    let raw_header = slp_indexer
+        .blocks()
+        .raw_header(&block)?
+        .expect("Inconsistent index");
     let txs = slp_indexer.blocks().block_txs_by_height(block.height)?;
     let txs = txs.into_iter().map(rich_tx_to_proto).collect();
     let bitcoind_rpc = slp_indexer.bitcoind_rpc().clone();
@@ -281,9 +285,10 @@ async fn handle_block(
         median_timestamp,
     });
     Ok(Protobuf(proto::Block {
-        txs,
         block_info,
         block_details,
+        raw_header,
+        txs,
     }))
 }
 

--- a/chronik-http/tests/test_chronik.rs
+++ b/chronik-http/tests/test_chronik.rs
@@ -527,11 +527,19 @@ async fn test_server() -> Result<()> {
             nonce: 0,
             median_timestamp: 2100000019,
         };
+        let raw_header = hex::decode(
+            "d72912f6f5e54f2ef8d4bdf97fdab91f23457997a996aa3dff0a73edf1f8ca58ffff7f2014752b7d000\
+             000000000000000000000\
+             01870100000000006f0000000000000000000000000000000000000000000000000000000000000000000000\
+             14fcf518fdbf1dd719c019ae1273c30619028142ec3cf4ffb67c0681c63c4e82\
+             1406e05881e299367766d313e26c05564ec91bf721d31726bd6e46e60689539a"
+        )?;
         assert_eq!(
             proto_block,
             proto::Block {
                 block_info: Some(block_info),
                 block_details: Some(block_details),
+                raw_header,
                 txs: vec![proto_block.txs[0].clone(), expected_tx],
             }
         );

--- a/chronik-rocksdb/src/block_stats.rs
+++ b/chronik-rocksdb/src/block_stats.rs
@@ -138,7 +138,10 @@ impl<'a> BlockStatsReader<'a> {
 
     pub fn by_height(&self, block_height: BlockHeight) -> Result<Option<BlockStats>> {
         let block_height = BlockHeightZC::new(block_height);
-        let block_stats = match self.db.get(self.cf_block_stats(), block_height.as_bytes())? {
+        let block_stats = match self
+            .db
+            .get(self.cf_block_stats(), block_height.as_bytes())?
+        {
             Some(block_stats) => block_stats,
             None => return Ok(None),
         };


### PR DESCRIPTION
Currently, there's no simple way to access the raw block header other than reconstructing it by hand.

This change adds it to the `Block` message.