### PR TITLE
[Fix] Fix bug when reorging SLP txs

### DIFF
--- a/chronik-rocksdb/src/slp.rs
+++ b/chronik-rocksdb/src/slp.rs
@@ -638,16 +638,18 @@ impl<'a> SlpWriter<'a> {
             batch.delete_cf(self.cf_slp_tx_data(), tx_num_zc.as_bytes());
             batch.delete_cf(self.cf_slp_tx_invalid_message(), tx_num_zc.as_bytes());
             if let Some((delete_token_num, delete_slp)) = delete_token {
-                let delete_token_num_zc = TokenNumZC::new(delete_token_num);
-                batch.delete_cf(
-                    self.cf_slp_token_id_by_num(),
-                    delete_token_num_zc.as_bytes(),
-                );
-                batch.delete_cf(self.cf_slp_token_metadata(), delete_token_num_zc.as_bytes());
-                batch.delete_cf(
-                    self.cf_slp_token_num_by_id(),
-                    delete_slp.slp_tx_data.token_id.as_slice_be(),
-                );
+                if matches!(delete_slp.slp_tx_data.slp_tx_type, SlpTxType::Genesis(_)) {
+                    let delete_token_num_zc = TokenNumZC::new(delete_token_num);
+                    batch.delete_cf(
+                        self.cf_slp_token_id_by_num(),
+                        delete_token_num_zc.as_bytes(),
+                    );
+                    batch.delete_cf(self.cf_slp_token_metadata(), delete_token_num_zc.as_bytes());
+                    batch.delete_cf(
+                        self.cf_slp_token_num_by_id(),
+                        delete_slp.slp_tx_data.token_id.as_slice_be(),
+                    );
+                }
                 token_num_by_id
                     .entry(delete_slp.slp_tx_data.token_id.token_id_be())
                     .or_insert(delete_token_num);


### PR DESCRIPTION
Previously, a refactor in 4d5fccc6efad1aa1761af6100f3a11590dc298c9 introduced a bug when reorging a block with SLP txs.

The refactor changed the behavior of `fetch_delete_data`, such that it would always return `Some((TokenNum, SlpValidTxData))` for all valid SLP txs, wheras previously it'd only return `Some((TokenNum, TokenId))` for GENESIS txs.

However, `delete_block_txs` would still assume that `fetch_delete_data` only returned data for GENESIS txs, and delete accordingly, which would delete token data even for `SEND` and `MINT` txs.

This PR changes it so that it only deletes token data if `fetch_delete_data` returned a GENESIS tx. We do this instead of reverting the refactor that introduced the bug, because the calculation of token stats requires this extra data.