### PR TITLE
Fix a bug when indexing a tx that burns Token Type 2 txs

### DIFF
--- a/chronik-rocksdb/src/slp.rs
+++ b/chronik-rocksdb/src/slp.rs
@@ -472,6 +472,9 @@ impl<'a> SlpWriter<'a> {
             // SEND already has the burns calculated
             Some(valid_slp_tx) if valid_slp_tx.slp_tx_data.slp_tx_type == SlpTxType::Send => {
                 for burn in valid_slp_tx.slp_burns.iter().flatten() {
+                    if burn.token.amount == SlpAmount::ZERO || burn.token_id == null_token {
+                        continue;
+                    }
                     let burned_amount = burned.entry(burn.token_id.token_id_be()).or_default();
                     *burned_amount += burn.token.amount.base_amount();
                 }


### PR DESCRIPTION
We use the token ID 000...000 for invalid/unknown SLP txs, and this currently includes Token Type 2 txs.

This fixes a bug where a tx burns TT2 tokens breaks the indexer because it's trying to calculate token stats for the token with ID 000...000.

The fix is to skip burns that have a token ID of 000...000.

In the future, properly indexing Token Type 2 txs would be preferable.